### PR TITLE
Change of the default order to put the windows of the current desktop first.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ The method also returns the previous sort order, in case you want to restore it 
 Note that the sort order is currently not persisted anywhere
 (it will start as *default* in each new GNOME Shell session).
 
-Similarly, you can prioritize the windows of the current desktop by calling setCurrentDesktopFirst(true). The default
-value is false. Like setSortOrder, it returns its previous value.
+Similarly, you can prioritize the windows of the current desktop by calling **setCurrentDesktopFirst** with `true`.
+The default value is `false`.
+Like setSortOrder, it returns its previous value.
 
 ## Command line usage
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ The method also returns the previous sort order, in case you want to restore it 
 Note that the sort order is currently not persisted anywhere
 (it will start as *default* in each new GNOME Shell session).
 
+Similarly, you can prioritize the windows of the current desktop by calling setCurrentDesktopFirst(true). The default
+value is false. Like setSortOrder, it returns its previous value.
+
 ## Command line usage
 
 You can call these methods using your favorite D-Bus command line tool, for example:

--- a/extension.js
+++ b/extension.js
@@ -129,7 +129,7 @@ export default class ActivateWindowByTitle {
             else {
                 yield* windows;
             }
-            return; 
+            return;
         }
 
         let sorter = null;

--- a/extension.js
+++ b/extension.js
@@ -103,16 +103,25 @@ export default class ActivateWindowByTitle {
     *#getWindows() {
         // note: in some future release, this might need to become global.compositor.get_window_actors()
         // (available since GNOME 48); for now, both seem to work and return the same array
-        const actors = global.get_window_actors();
+        const active_workspace = global.get_workspace_manager().get_active_workspace();
+        const windows = global.get_window_actors().map(actor => actor.get_meta_window());
 
         if (this.#sortOrder === 'default') {
-            for (const actor of actors) {
-                yield actor.get_meta_window();
+            const ordered_windows = [];
+            let active_workspace_count = 0;
+            for (const tmp_window of windows) {
+                if (tmp_window.get_workspace() === active_workspace) {
+                    ordered_windows.splice(active_workspace_count, 0, tmp_window);
+                    ++active_workspace_count;
+                }
+                else {
+                    ordered_windows.push(tmp_window);
+                }
             }
+            yield *ordered_windows;
             return;
         }
 
-        const windows = actors.map(actor => actor.get_meta_window());
         let sorter = null;
 
         switch (this.#sortOrder) {

--- a/extension.js
+++ b/extension.js
@@ -53,6 +53,10 @@ const ActivateWindowByTitleInterface = `
       <arg name="newSortOrder" type="s" direction="in" />
       <arg name="oldSortOrder" type="s" direction="out" />
     </method>
+    <method name="setCurrentDesktopFirst">
+      <arg name="newCurrentDesktopFirst" type="b" direction="in" />
+      <arg name="oldCurrentDesktopFirst" type="b" direction="out" />
+    </method>
   </interface>
 </node>
 `;
@@ -60,6 +64,7 @@ const ActivateWindowByTitleInterface = `
 export default class ActivateWindowByTitle {
     #dbus;
     #sortOrder = 'default';
+    #currentDesktopFirst = false;
     static #sortOrders = new Set([
         'default',
         'lowest_user_time',
@@ -107,19 +112,24 @@ export default class ActivateWindowByTitle {
         const windows = global.get_window_actors().map(actor => actor.get_meta_window());
 
         if (this.#sortOrder === 'default') {
-            const ordered_windows = [];
-            let active_workspace_count = 0;
-            for (const tmp_window of windows) {
-                if (tmp_window.get_workspace() === active_workspace) {
-                    ordered_windows.splice(active_workspace_count, 0, tmp_window);
-                    ++active_workspace_count;
+            if (this.#currentDesktopFirst) {
+                const ordered_windows = [];
+                let active_workspace_count = 0;
+                for (const tmp_window of windows) {
+                    if (tmp_window.get_workspace() === active_workspace) {
+                        ordered_windows.splice(active_workspace_count, 0, tmp_window);
+                        ++active_workspace_count;
+                    }
+                    else {
+                        ordered_windows.push(tmp_window);
+                    }
                 }
-                else {
-                    ordered_windows.push(tmp_window);
-                }
+                yield* ordered_windows;
             }
-            yield *ordered_windows;
-            return;
+            else {
+                yield* windows;
+            }
+            return; 
         }
 
         let sorter = null;
@@ -144,6 +154,22 @@ export default class ActivateWindowByTitle {
                 );
         }
 
+        if (this.#currentDesktopFirst) {
+            const raw_sorter = sorter;
+            sorter = function(w1, w2) {
+                const w1_workspace = w1.get_workspace();
+                const w2_workspace = w2.get_workspace();
+                if (w1_workspace !== w2_workspace) {
+                    if (w1_worspace === active_workspace) {
+                        return -1;
+                    }
+                    else if (w2_workspace === active_workspace) {
+                        return 1;
+                    }
+                }
+                return raw_sorter(w1, w2);
+            };
+        }
         windows.sort(sorter);
 
         yield* windows;
@@ -224,5 +250,11 @@ export default class ActivateWindowByTitle {
         const oldSortOrder = this.#sortOrder;
         this.#sortOrder = newSortOrder;
         return oldSortOrder;
+    }
+
+    setCurrentDesktopFirst(newCurrentDesktopFirst) {
+        const oldCurrentDesktopFirst = this.#currentDesktopFirst;
+        this.#currentDesktopFirst = newCurrentDesktopFirst;
+        return oldCurrentDesktopFirst;
     }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "uuid": "activate-window-by-title@lucaswerkmeister.de",
   "name": "Activate Window By Title",
   "description": "Expose a D-Bus interface to activate a window by its title, WM_CLASS or ID",
-  "version": 11,
+  "version": 12,
   "shell-version": [
     "45",
     "46",


### PR DESCRIPTION
For the default order, I just made the windows of the current desktop first on the list. Oderwise, the order is not changed. This will activate the window on the current desktop if one is found. Otherwise, it will work just like before.