### PR TITLE
Added 'activateByTitleContainsConditions' to enable conditional title…

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -37,6 +37,10 @@ const ActivateWindowByTitleInterface = `
       <arg name="substring" type="s" direction="in" />
       <arg name="found" type="b" direction="out" />
     </method>
+    <method name="activateByTitleContainsConditions">
+      <arg name="titleWithConditions" type="s" direction="in" />
+      <arg name="found" type="b" direction="out" />
+    </method>
     <method name="activateByWmClass">
       <arg name="name" type="s" direction="in" />
       <arg name="found" type="b" direction="out" />
@@ -209,6 +213,18 @@ export default class ActivateWindowByTitle {
             (title) => title.includes(substring),
         );
     }
+    
+    activateByTitleContainsConditions(titleWithConditions) {
+        let evenReplace = true;
+        while(titleWithConditions.includes("#")) {
+            titleWithConditions = titleWithConditions.replace("#", evenReplace ? "title.includes(\"" : "\")");
+            evenReplace = !evenReplace;
+        }
+        return this.#activateByTitlePredicate(
+            (title) => eval(titleWithConditions) === true
+        );
+    }
+
 
     // note: we don’t offer activateByRegExp,
     // because that would be vulnerable to ReDoS attacks


### PR DESCRIPTION
Have noticed that regex is not allowed. Need this method for other purposes.

busctl --user call org.gnome.Shell /de/lucaswerkmeister/ActivateWindowByTitle de.lucaswerkmeister.ActivateWindowByTitle  activateByTitleContainsConditions s '(#notes.txt#||#notes2.txt#)&&#Text Editor#'

Allows queries like '(#notes.txt#||#notes2.txt#)&&#Text Editor#' or more complex without regex. As long is the boolean logic "||", "&&" and parenthesis are proper, it will match title. Please suggest changes if needed.